### PR TITLE
Added tesseract path for macOS

### DIFF
--- a/src/main/org/audiveris/omr/WellKnowns.java
+++ b/src/main/org/audiveris/omr/WellKnowns.java
@@ -454,7 +454,8 @@ public abstract class WellKnowns
             }
         }
 
-        throw new InstallationException("Tesseract-OCR is not installed");
+        throw new InstallationException("Tesseract data could not be found. " +
+                "Try setting the TESSDATA_PREFIX environment variable to the parent folder of \"tessdata\".");
     }
 
     //-----------------//

--- a/src/main/org/audiveris/omr/WellKnowns.java
+++ b/src/main/org/audiveris/omr/WellKnowns.java
@@ -442,6 +442,8 @@ public abstract class WellKnowns
             final String pf32 = OS_ARCH.equals("x86") ? "ProgramFiles" : "ProgramFiles(x86)";
 
             return Paths.get(System.getenv(pf32)).resolve("tesseract-ocr");
+        } else if (MAC_OS_X) {
+            return Paths.get("/usr/local/opt/tesseract/share");
         } else {
             throw new InstallationException("Tesseract-OCR is not installed");
         }

--- a/src/main/org/audiveris/omr/WellKnowns.java
+++ b/src/main/org/audiveris/omr/WellKnowns.java
@@ -443,10 +443,18 @@ public abstract class WellKnowns
 
             return Paths.get(System.getenv(pf32)).resolve("tesseract-ocr");
         } else if (MAC_OS_X) {
-            return Paths.get("/usr/local/opt/tesseract/share");
-        } else {
-            throw new InstallationException("Tesseract-OCR is not installed");
+            // Default path when installed with homebrew
+            final Path brewPath = Paths.get("/usr/local/opt/tesseract/share");
+            // Default path when installed with macports
+            Path portPath = Paths.get("/opt/local/share");
+            if (Files.exists(brewPath.resolve("tessdata"))) {
+                return brewPath;
+            } else if (Files.exists(portPath.resolve("tessdata"))) {
+                return portPath;
+            }
         }
+
+        throw new InstallationException("Tesseract-OCR is not installed");
     }
 
     //-----------------//


### PR DESCRIPTION
This fixes #3 by adding an additional fallback directory for macOS.
The fallback path is the default content path for tesseract, when it is installed with Homebrew.
Since Homebrew is the most common macOS package manager, this should resolve the issue in most  cases.